### PR TITLE
Fix freeze when players are queued on 3v3 rated

### DIFF
--- a/src/solo3v3.h
+++ b/src/solo3v3.h
@@ -35,7 +35,7 @@ constexpr uint32 ARENA_TEAM_SOLO_3v3 = 4;
 constexpr uint32 ARENA_TYPE_3v3_SOLO = 4;
 constexpr uint32 ARENA_SLOT_SOLO_3v3 = 4;
 constexpr uint32 BATTLEGROUND_QUEUE_3v3_SOLO = 12;
-constexpr BattlegroundQueueTypeId bgQueueTypeId = (BattlegroundQueueTypeId)((int)BATTLEGROUND_QUEUE_3v3);
+constexpr BattlegroundQueueTypeId bgQueueTypeId = (BattlegroundQueueTypeId)((int)12);
 
 
 const uint32 FORBIDDEN_TALENTS_IN_1V1_ARENA[] =

--- a/src/solo3v3.h
+++ b/src/solo3v3.h
@@ -35,7 +35,7 @@ constexpr uint32 ARENA_TEAM_SOLO_3v3 = 4;
 constexpr uint32 ARENA_TYPE_3v3_SOLO = 4;
 constexpr uint32 ARENA_SLOT_SOLO_3v3 = 4;
 constexpr uint32 BATTLEGROUND_QUEUE_3v3_SOLO = 12;
-constexpr BattlegroundQueueTypeId bgQueueTypeId = (BattlegroundQueueTypeId)((int)12);
+constexpr BattlegroundQueueTypeId bgQueueTypeId = (BattlegroundQueueTypeId)((int) BATTLEGROUND_QUEUE_3v3_SOLO);
 
 
 const uint32 FORBIDDEN_TALENTS_IN_1V1_ARENA[] =


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

When queueing rated 3v3 arenas, the server freezes, this fixes it.

## Changes Proposed:
- 
- 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
