### PR TITLE
Fix crash when watching a solo 3v3 arena Replay

### DIFF
--- a/src/solo3v3.cpp
+++ b/src/solo3v3.cpp
@@ -162,6 +162,14 @@ void Solo3v3::CleanUp3v3SoloQ(Battleground* bg)
 
 void Solo3v3::CheckStartSolo3v3Arena(Battleground* bg)
 {
+    // Fix crash with Arena Replay module
+    for (const auto& playerPair : bg->GetPlayers())
+    {
+        Player* player = playerPair.second;
+        if (player->IsSpectator())
+            return;
+    }
+
     if (bg->GetArenaType() != ARENA_TYPE_3v3_SOLO)
         return;
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

With the module mod-arena-replay, it's possible to watch a replay of a game, but when watching a replay of a solo 3v3 it causes a crash, this fixes it.

## Changes Proposed:
- 
- 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
