### PR TITLE
Fix: Replayed games counting as a loss

### DIFF
--- a/src/solo3v3.cpp
+++ b/src/solo3v3.cpp
@@ -43,6 +43,9 @@ uint32 Solo3v3::GetAverageMMR(ArenaTeam* team)
 
 void Solo3v3::CountAsLoss(Player* player, bool isInProgress)
 {
+    if (player->IsSpectator())
+        return;
+
     ArenaTeam* plrArenaTeam = sArenaTeamMgr->GetArenaTeamById(player->GetArenaTeamId(ARENA_SLOT_SOLO_3v3));
 
     if (!plrArenaTeam)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Replayed games no longer decreases rating/counts as a loss

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes a issue reported in https://github.com/azerothcore/mod-arena-3v3-solo-queue/issues/25#issuecomment-2469631977

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- I replayed a solo 3v3 game that i previous played and left the replay and checked that it no longer reduces my solo team rating


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Must have https://github.com/azerothcore/mod-arena-replay
2. Play a solo 3v3 game
3. Check the amount of rating/games played (either through database or statistics through solo 3v3 npc)
4. Go to the Replay Arena NPC and watch a replay of a solo 3v3 game.
5. While on the replay, click to leave the match (on the mini-map button)
6. See that the rating and amount of games are still the same as before
