### PR TITLE
fix: prevent SoloQ arena team creation while player is in a party or raid

### DIFF
--- a/src/solo3v3_sc.cpp
+++ b/src/solo3v3_sc.cpp
@@ -571,6 +571,13 @@ bool NpcSolo3v3::CreateArenateam(Player* player, Creature* /*creature*/)
     if (!player)
         return false;
 
+    // Player cannot be in a party or raid
+    if (player->GetGroup())
+    {
+        ChatHandler(player->GetSession()).SendSysMessage("You must leave your party or raid before creating a SoloQ arena team.");
+        return false;
+    }
+
     // Check if player is already in an arena team
     if (player->GetArenaTeamId(ARENA_SLOT_SOLO_3v3))
     {


### PR DESCRIPTION
- Prevents creation of orphan SoloQ arena teams.
- Prevents gold loss when attempting to create a SoloQ team while grouped.
- Displays a clear message instructing the player to leave their party or raid first.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- 
- 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Players can no longer create a SoloQ 3v3 arena team while in a party or raid.
  * A system message now instructs players to leave their party or raid before creating a team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->